### PR TITLE
Added globalize.cultures.min.js

### DIFF
--- a/Config/Resources.xml
+++ b/Config/Resources.xml
@@ -102,7 +102,8 @@
 
   <resource>
     <name>cultures</name>
-    <script>/Syncfusion/external/jquery.globalize.js</script>
+    <script>/Syncfusion/external/jquery.globalize.js</script
+    <script>/Syncfusion/external/globalize.cultures.min.js</script>
   </resource>
 
   <resource>


### PR DESCRIPTION
Otherwise Datepicker (and possibly more) cannot be fully localized (i.e. to consider german date-format)