### PR TITLE
Fixed invalid Set-Call

### DIFF
--- a/MS3/Code/Templates/MiPageSample.dyalog
+++ b/MS3/Code/Templates/MiPageSample.dyalog
@@ -26,7 +26,7 @@
           Body.Push _.div'id="contentblock"'
      
         ⍝ add a hidden division to the body containing the APL source code
-          (Add _.div(#.HTMLInput.APLToHTMLColour src←⎕SRC⊃⊃⎕CLASS ⎕THIS)).Set'id="codeblock"' 'style="display: none;"'
+          (Add _.div(#.HTMLInput.APLToHTMLColour src←⎕SRC⊃⊃⎕CLASS ⎕THIS)).Set'id="codeblock" style="display:none;"'
      
         ⍝ create a division with info about the controls used
           ctrlsdiv←CtrlsDiv src


### PR DESCRIPTION
This created invalid syntax:
div id="codeblock"="style=&quot;display:none;&quot;"><pre style="font-family:APL385 Unicode"

(As I reported on Nov 27, 2015)