### PR TITLE
Removed top-margin from default-style (for Panel). 

### DIFF
--- a/PlugIns/Dyalog/dcPanel/dcPanel.css
+++ b/PlugIns/Dyalog/dcPanel/dcPanel.css
@@ -27,11 +27,6 @@
   vertical-align: middle;
 }
 
-.dc-panel {
-  margin-top: 16px;
-}
-
-
 .dc-panel > .dc-panel-icon  + .dc-panel-content {
   border-top-left-radius: .5em;
   border-top-right-radius: .5em;


### PR DESCRIPTION
If desired, it should be in a site's css instead.