### PR TITLE
Fix language usage statistics

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -16,5 +16,8 @@
 *.rtf	 diff=astextplain
 *.RTF	 diff=astextplain
 
+# Fix classification of unrecognised filetypes on GitHub.com
+*.mipage linguist-language=APL
+
 # don't count third-party code in languag analysis
 PlugIns/**/* linguist-vendored

--- a/.gitattributes
+++ b/.gitattributes
@@ -17,4 +17,4 @@
 *.RTF	 diff=astextplain
 
 # don't count third-party code in languag analysis
-PlugIns/* linguist-vendored
+PlugIns/**/* linguist-vendored


### PR DESCRIPTION
The override attempted in 74ef850 only applied the `linguist-vendored` attribute to the _immediate_ descendants of the `PlugIns/` directory:

~~~console
$ git check-attr linguist-vendored PlugIns/Syncfusion-15.3.0.33
PlugIns/Syncfusion-15.3.0.33: linguist-vendored: set
$ git check-attr linguist-vendored PlugIns/Syncfusion-15.3.0.33/assets
PlugIns/Syncfusion-15.3.0.33: linguist-vendored: unspecified
~~~

Linguist's [overrides](https://github.com/github/linguist/blob/master/docs/overrides.md) aren't inherited by files when applied to a directory, so the attempt to exclude `PlugIns` from the project's language stats didn't work. This PR fixes that:

~~~console
$ git check-attr linguist-vendored PlugIns/Syncfusion-15.3.0.33/assets
PlugIns/Syncfusion-15.3.0.33/assets: linguist-vendored: set
$ git check-attr linguist-vendored PlugIns/Syncfusion-15.3.0.33/assets/css/mobile/ej.mobile.all.css
PlugIns/Syncfusion-15.3.0.33/assets/css/mobile/ej.mobile.all.css: linguist-vendored: set
~~~