### PR TITLE
fixes #79

### DIFF
--- a/HTML/_DC/Select.dyalog
+++ b/HTML/_DC/Select.dyalog
@@ -73,7 +73,7 @@
      
       :If ~0∊⍴Prompt
       :AndIf 0∊⍴⊃Attrs[⊂'multiple']  ⍝ prompt makes no sense if multiple selections are allowed
-          r,←(('disabled="disabled" ',(~∨/sel)/'selected="selected"')New #._html.option Prompt).Render
+          r,←(('disabled="disabled" value=""',(~∨/sel)/'selected="selected"')New #._html.option Prompt).Render
       :EndIf
      
       r,←FormatOptions(opts sel dis)


### PR DESCRIPTION
Not specifying the `value ` attribute is different from passing an empty `value` - this fix deals with that. As a consequence, `select` controls with the `required` attribute will be detected and reported by HTML5 form validation.